### PR TITLE
remove node engines from package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
       "email": "post@trygve-lie.com"
     }
   ],
-  "engines": {
-    "node": "4.x"
-  },
   "bugs": {
     "url": "https://github.com/trygve-lie/through-batch/issues"
   },


### PR DESCRIPTION
When installing this module with yarn it complains unless you have the same engine version, do you mind just removing this from package.json?